### PR TITLE
Send HTTP Accept header when fetching an RSS feed

### DIFF
--- a/rss-v2-parser.go
+++ b/rss-v2-parser.go
@@ -260,7 +260,13 @@ func ParseURL(url string) (*RSSV2, string, error) {
 }
 
 func getContent(url string) ([]byte, error) {
-	resp, err := http.DefaultClient.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Accept", "application/rss+xml") // http://www.rssboard.org/rss-mime-type-application.txt
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Set the Accept header to application/rss+xml to improve compatibility with
sites that serve different content based on the Accept header's value. Some of
these sites require the header set to application/rss+xml to reply with a valid
RSS feed.